### PR TITLE
Fix failing React test

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Bank Statement Uploader header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/Bank Statement Uploader/i);
+  expect(headerElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fix the failing App.test.js to match the current UI

## Testing
- `pytest`
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ef035c2388321844544ce7646aad0